### PR TITLE
Fix for bookworm

### DIFF
--- a/library/unicornhatmini/__init__.py
+++ b/library/unicornhatmini/__init__.py
@@ -47,7 +47,7 @@ class UnicornHATMini():
         self._rotation = 0
 
         for device, pin, offset in self.left_matrix, self.right_matrix:
-            device.no_cs = True
+            device.no_cs = False
             device.max_speed_hz = spi_max_speed_hz
             self.xfer(device, pin, [CMD_SOFT_RESET])
             self.xfer(device, pin, [CMD_GLOBAL_BRIGHTNESS, 0x01])

--- a/library/unicornhatmini/__init__.py
+++ b/library/unicornhatmini/__init__.py
@@ -7,8 +7,6 @@ import spidev
 
 from colorsys import hsv_to_rgb
 
-import RPi.GPIO as GPIO
-
 __version__ = '0.0.2'
 
 
@@ -45,16 +43,12 @@ class UnicornHATMini():
         self.left_matrix = (spidev.SpiDev(0, 0), 8, 0)
         self.right_matrix = (spidev.SpiDev(0, 1), 7, 28 * 8)
 
-        GPIO.setwarnings(False)
-        GPIO.setmode(GPIO.BCM)
-
         self.buf = [0 for _ in range(28 * 8 * 2)]
         self._rotation = 0
 
         for device, pin, offset in self.left_matrix, self.right_matrix:
             device.no_cs = True
             device.max_speed_hz = spi_max_speed_hz
-            GPIO.setup(pin, GPIO.OUT, initial=GPIO.HIGH)
             self.xfer(device, pin, [CMD_SOFT_RESET])
             self.xfer(device, pin, [CMD_GLOBAL_BRIGHTNESS, 0x01])
             self.xfer(device, pin, [CMD_SCROLL_CTRL, 0x00])
@@ -76,9 +70,7 @@ class UnicornHATMini():
         self._shutdown()
 
     def xfer(self, device, pin, command):
-        GPIO.output(pin, GPIO.LOW)
         device.xfer2(command)
-        GPIO.output(pin, GPIO.HIGH)
 
     def set_pixel(self, x, y, r, g, b):
         """Set a single pixel."""


### PR DESCRIPTION
Rely on spidev's chip select rather than manually triggering GPIO pins. 

This fixes #16, where Bookworm has stricter checks on using GPIO pins. 

Unsure if this change would impact older versions of Raspbian, or why the decision to manually assert/deassert GPIO 7 and GPIO 8 SPI chip select in the first place.